### PR TITLE
Fix CMake Error at cmake/Targets.cmake:85 (list): list sub-command RE…

### DIFF
--- a/cmake/Targets.cmake
+++ b/cmake/Targets.cmake
@@ -82,7 +82,9 @@ function(caffe_pickup_caffe_sources root)
   # collect cuda files
   file(GLOB    test_cuda ${root}/src/caffe/test/test_*.cu)
   file(GLOB_RECURSE cuda ${root}/src/caffe/*.cu)
-  list(REMOVE_ITEM  cuda ${test_cuda})
+  if (${test_cuda})
+    list(REMOVE_ITEM cuda ${test_cuda})
+  endif()
 
   # add proto to make them editable in IDEs too
   file(GLOB_RECURSE proto_files ${root}/src/caffe/*.proto)


### PR DESCRIPTION
Fix CMake Error:
CMake Error at cmake/Targets.cmake:85 (list):
  list sub-command REMOVE_ITEM requires two or more arguments.
Call Stack (most recent call first):
  src/caffe/CMakeLists.txt:13 (caffe_pickup_caffe_sources)

You have called ADD_LIBRARY for library caffe without any source files. This typically indicates a problem with your CMakeLists.txt file
CMake Error at src/caffe/test/CMakeLists.txt:29 (add_executable):
  add_executable called with incorrect number of arguments, no sources
  provided

CMake Error at src/caffe/test/CMakeLists.txt:30 (target_link_libraries):
  Cannot specify link libraries for target "test.testbin" which is not built
  by this project.

-- Configuring incomplete, errors occurred!