### PR TITLE
fixed miopen convolutions

### DIFF
--- a/src/caffe/layers/cudnn_conv_layer.cpp
+++ b/src/caffe/layers/cudnn_conv_layer.cpp
@@ -277,6 +277,19 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
         &workspace_bwd_filter_sizes_[i] // workSpaceSize
     ));
 #endif // USE_MIOPEN_BACKWARD_WEIGHT
+
+#ifdef USE_MIOPEN_BACKWARD_DATA
+    // get workspace for backwards filter algorithm
+    MIOPEN_CHECK(miopenConvolutionBackwardDataGetWorkSpaceSize(
+        handle_[0],
+        top_descs_[i],                  // dyDesc
+        filter_desc_,                   // wDesc
+        conv_descs_[i],                 // convDesc
+        bottom_descs_[i],               // dxDesc
+        &workspace_bwd_data_sizes_[i] // workSpaceSize
+    ));
+
+#endif // USE_MIOPEN_BACKWARD_DATA
 #endif // USE_MIOPEN
     LOG(INFO) << "After miopenConvolution*GetWorkSpaceSize\n";
 
@@ -451,7 +464,7 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
     if (skipFindFwd) {
         fwd_algo_[i] = miopenConvolutionFwdAlgoGEMM;
     }  else {
-        LOG(INFO) << "Before miopenFindConvolutionBackwardWeightsAlgorithm\n";
+        LOG(INFO) << "Before miopenFindConvolutionForwardAlgorithm\n";
         // choose forward and backward algorithms + workspace(s)
         MIOPEN_CHECK(miopenFindConvolutionForwardAlgorithm(
             handle_[0*this->group_ + g],               // handle
@@ -465,8 +478,8 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
             1,                        // requestAlgoCount
             &ret_algo_count,          // returnedAlgoCount
             &perf,                    // perfResults
-            NULL,                     // workSpace
-            0,                        // workSpaceSize
+            workspace[0],             // workSpace
+            max_workspace,            // workSpaceSize
             false                     // exhaustiveSearch
         ));
         fwd_algo_[i] = perf.fwd_algo;


### PR DESCRIPTION
A couple of fixes to improve convolution performance. The fix has been tested on hipCaffe:v15.0 image on Fiji. Would be worthwhile to test on Vega before merging.

MIOpenDriver and caffe "time" command track fairly well now for convolutions.