### PR TITLE
enabled miopen pooling

### DIFF
--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -97,11 +97,16 @@ shared_ptr<Layer<Dtype> > GetPoolingLayer(const LayerParameter& param) {
     // Until there is a workaround in Caffe (index management) or
     // cuDNN, use Caffe layer to max pooling, or don't use in place
     // layers after max pooling layers
+
+#if 0 // This check was disbaling MIOpen because cuDNN did not support something
     if (param.pooling_param().pool() == PoolingParameter_PoolMethod_MAX) {
         return shared_ptr<Layer<Dtype> >(new PoolingLayer<Dtype>(param));
     } else {
+#endif // 0
         return shared_ptr<Layer<Dtype> >(new CuDNNPoolingLayer<Dtype>(param));
+#if 0
     }
+#endif // 0
 #endif
   } else {
     LOG(FATAL) << "Layer " << param.name() << " has unknown engine.";


### PR DESCRIPTION
This fix enables caffe to use MIOpen for MAX_POOLING. This was disabled for some reason which cuDNN does not / did not support. Looking at NVIDIA's [github](https://github.com/NVIDIA/caffe/blob/caffe-0.16/src/caffe/layer_factory.cpp#L134) itself makes me believe that they have fixed this limitation.

Highly recommend to run training with this fix to ensure this does not manifest in accuracy issues. I am suspecting all this while we were not using MIOpen for pooling in our training runs.

cc\ @ashishfarmer This might also be the reason for the discrepancy you saw between ocl and hip caffe for pooling.