### PR TITLE
Abolish new/delete in Convolution layer

### DIFF
--- a/include/caffe/internal_thread.hpp
+++ b/include/caffe/internal_thread.hpp
@@ -18,7 +18,7 @@ namespace caffe {
  */
 class InternalThread {
  public:
-  InternalThread() : thread_() {}
+  InternalThread() : device_(0), thread_() {}
   virtual ~InternalThread();
 
   /**
@@ -34,6 +34,8 @@ class InternalThread {
   bool is_started() const;
 
  protected:
+  int device_;
+
   /* Implement this method in your subclass
       with the code you want your thread to run. */
   virtual void InternalThreadEntry() {}

--- a/include/caffe/layers/cudnn_conv_layer.hpp
+++ b/include/caffe/layers/cudnn_conv_layer.hpp
@@ -29,8 +29,12 @@ namespace caffe {
 template <typename Dtype>
 class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
  public:
-  explicit CuDNNConvolutionLayer(const LayerParameter& param)
-      : ConvolutionLayer<Dtype>(param), handles_setup_(false) {}
+#ifdef CONV_LAYER_COUNT
+  static int count;
+#endif
+
+  explicit CuDNNConvolutionLayer(const LayerParameter& param);
+
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
@@ -47,8 +51,6 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
   bool handles_setup_;
 
 #ifdef USE_MIOPEN
-  miopenHandle_t* handle_;
-  hipStream_t*    stream_;
 
   // algorithms for forward and backwards convolutions
   miopenConvFwdAlgorithm_t*        fwd_algo_;
@@ -86,6 +88,7 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
   size_t workspaceSizeInBytes;  // size of underlying storage
   void *workspaceData;  // underlying storage
   void **workspace;  // aliases into workspaceData
+  miopenHandle_t handle_;
 };
 #endif
 

--- a/include/caffe/layers/cudnn_conv_layer.hpp
+++ b/include/caffe/layers/cudnn_conv_layer.hpp
@@ -47,7 +47,7 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
-
+public:
   bool handles_setup_;
 
 #ifdef USE_MIOPEN

--- a/include/caffe/layers/cudnn_conv_layer.hpp
+++ b/include/caffe/layers/cudnn_conv_layer.hpp
@@ -65,21 +65,6 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
   int N_, C_, W_, H_;
 #endif
 
-#ifdef USE_CUDNN
-  cudnnHandle_t* handle_;
-  cudaStream_t*  stream_;
-
-  // algorithms for forward and backwards convolutions
-  cudnnConvolutionFwdAlgo_t *fwd_algo_;
-  cudnnConvolutionBwdFilterAlgo_t *bwd_filter_algo_;
-  cudnnConvolutionBwdDataAlgo_t *bwd_data_algo_;
-
-  vector<cudnnTensorDescriptor_t> bottom_descs_, top_descs_;
-  cudnnTensorDescriptor_t    bias_desc_;
-  cudnnFilterDescriptor_t      filter_desc_;
-  vector<cudnnConvolutionDescriptor_t> conv_descs_;
-#endif
-
   int bottom_offset_, top_offset_, bias_offset_;
 
   size_t *workspace_fwd_sizes_;

--- a/include/caffe/layers/cudnn_conv_layer.hpp
+++ b/include/caffe/layers/cudnn_conv_layer.hpp
@@ -53,9 +53,9 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
 #ifdef USE_MIOPEN
 
   // algorithms for forward and backwards convolutions
-  miopenConvFwdAlgorithm_t*        fwd_algo_;
-  miopenConvBwdWeightsAlgorithm_t* bwd_weight_algo_;
-  miopenConvBwdDataAlgorithm_t*    bwd_data_algo_;
+  vector<miopenConvFwdAlgorithm_t>        fwd_algo_;
+  vector<miopenConvBwdWeightsAlgorithm_t> bwd_weight_algo_;
+  vector<miopenConvBwdDataAlgorithm_t>    bwd_data_algo_;
 
   vector<miopenTensorDescriptor_t>      bottom_descs_, top_descs_;
   miopenTensorDescriptor_t              bias_desc_;
@@ -63,17 +63,17 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
   vector<miopenConvolutionDescriptor_t> conv_descs_;
 
   int N_, C_, W_, H_;
+  miopenHandle_t handle_;
 #endif
 
   int bottom_offset_, top_offset_, bias_offset_;
 
-  size_t *workspace_fwd_sizes_;
-  size_t *workspace_bwd_data_sizes_;
-  size_t *workspace_bwd_filter_sizes_;
+  vector<size_t> workspace_fwd_sizes_;
+  vector<size_t> workspace_bwd_data_sizes_;
+  vector<size_t> workspace_bwd_filter_sizes_;
   size_t workspaceSizeInBytes;  // size of underlying storage
   void *workspaceData;  // underlying storage
-  void **workspace;  // aliases into workspaceData
-  miopenHandle_t handle_;
+  vector<void*>  workspace;  // aliases into workspaceData
 };
 #endif
 

--- a/include/caffe/layers/cudnn_conv_layer.hpp
+++ b/include/caffe/layers/cudnn_conv_layer.hpp
@@ -69,8 +69,8 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
   int bottom_offset_, top_offset_, bias_offset_;
 
   vector<size_t> workspace_fwd_sizes_;
-  vector<size_t> workspace_bwd_data_sizes_;
   vector<size_t> workspace_bwd_filter_sizes_;
+  vector<size_t> workspace_bwd_data_sizes_;
   size_t workspaceSizeInBytes;  // size of underlying storage
   void *workspaceData;  // underlying storage
   vector<void*>  workspace;  // aliases into workspaceData

--- a/src/caffe/internal_thread.cpp
+++ b/src/caffe/internal_thread.cpp
@@ -39,6 +39,7 @@ void InternalThread::entry(int device, Caffe::Brew mode, int rand_seed,
     int solver_count, bool root_solver) {
   LOG(INFO) << "Started internal thread on device " << device;
 #ifndef CPU_ONLY
+  LOG(INFO) << "Call hipSetDevice(" << device << ")";
   HIP_CHECK(hipSetDevice(device));
 #endif
   Caffe::set_mode(mode);

--- a/src/caffe/internal_thread.cpp
+++ b/src/caffe/internal_thread.cpp
@@ -20,18 +20,15 @@ bool InternalThread::must_stop() {
 
 void InternalThread::StartInternalThread() {
   CHECK(!is_started()) << "Threads should persist and not be restarted.";
+  LOG(INFO) << "Starting internal thread on device " << device_;
 
-  int device = 0;
-#ifndef CPU_ONLY
-  HIP_CHECK(hipGetDevice(&device));
-#endif
   Caffe::Brew mode = Caffe::mode();
   int rand_seed = caffe_rng_rand();
   int solver_count = Caffe::solver_count();
   bool root_solver = Caffe::root_solver();
 
   try {
-    thread_.reset(new boost::thread(&InternalThread::entry, this, device, mode,
+    thread_.reset(new boost::thread(&InternalThread::entry, this, device_, mode,
           rand_seed, solver_count, root_solver));
   } catch (std::exception& e) {
     LOG(FATAL) << "Thread exception: " << e.what();
@@ -40,6 +37,7 @@ void InternalThread::StartInternalThread() {
 
 void InternalThread::entry(int device, Caffe::Brew mode, int rand_seed,
     int solver_count, bool root_solver) {
+  LOG(INFO) << "Started internal thread on device " << device;
 #ifndef CPU_ONLY
   HIP_CHECK(hipSetDevice(device));
 #endif

--- a/src/caffe/layers/base_data_layer.cpp
+++ b/src/caffe/layers/base_data_layer.cpp
@@ -74,6 +74,7 @@ void BasePrefetchingDataLayer<Dtype>::LayerSetUp(
 
 template <typename Dtype>
 void BasePrefetchingDataLayer<Dtype>::InternalThreadEntry() {
+  LOG(INFO) << "BasePrefetchingDataLayer<Dtype>::InternalThreadEntry()";
 #ifndef CPU_ONLY
   hipStream_t stream = nullptr;
 #endif

--- a/src/caffe/layers/base_data_layer.cpp
+++ b/src/caffe/layers/base_data_layer.cpp
@@ -75,10 +75,7 @@ void BasePrefetchingDataLayer<Dtype>::LayerSetUp(
 template <typename Dtype>
 void BasePrefetchingDataLayer<Dtype>::InternalThreadEntry() {
 #ifndef CPU_ONLY
-  hipStream_t stream;
-  if (Caffe::mode() == Caffe::GPU) {
-    HIP_CHECK(hipStreamCreateWithFlags(&stream, hipStreamNonBlocking));
-  }
+  hipStream_t stream = nullptr;
 #endif
 
   try {
@@ -98,7 +95,8 @@ void BasePrefetchingDataLayer<Dtype>::InternalThreadEntry() {
   }
 #ifndef CPU_ONLY
   if (Caffe::mode() == Caffe::GPU) {
-    HIP_CHECK(hipStreamDestroy(stream));
+    if (stream != nullptr)
+      HIP_CHECK(hipStreamDestroy(stream));
   }
 #endif
 }

--- a/src/caffe/layers/cudnn_conv_layer.cpp
+++ b/src/caffe/layers/cudnn_conv_layer.cpp
@@ -326,6 +326,9 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
     perf.bwd_weights_algo = miopenConvolutionBwdWeightsAlgoDirect;
     perf.bwd_data_algo = miopenConvolutionBwdDataAlgoDirect;
 
+#ifdef USE_MIOPEN_FORWARD_CONV
+    DLOG(INFO) << "miopenFindConvolutionForwardAlgorithm\n";
+
     // choose forward and backward algorithms + workspace(s)
     MIOPEN_CHECK(miopenFindConvolutionForwardAlgorithm(
         handle_,                  // handle

--- a/src/caffe/layers/cudnn_conv_layer.cpp
+++ b/src/caffe/layers/cudnn_conv_layer.cpp
@@ -348,7 +348,7 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
     ));
 
     fwd_algo_[i] = perf.fwd_algo;
-    DLOG(INFO) << "fwd_algo_[" << i << "]: " << fwd_algo_[i] << "\n";
+    LOG(INFO) << " - fwd_algo_[" << i << "]:        " << fwd_algo_[i];
     DLOG(INFO) << "workspace_fwd_sizes_[" << i << "]:" << workspace_fwd_sizes_[i] << "\n";
 #endif
 
@@ -375,7 +375,7 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
     ));
 
     bwd_weight_algo_[i] = perf.bwd_weights_algo;
-    DLOG(INFO) << "bwd_weight_algo_[" << i << "]: " << bwd_weight_algo_[i] << "\n";
+    LOG(INFO) << " - bwd_weight_algo_[" << i << "]: " << bwd_weight_algo_[i];
     DLOG(INFO) << "workspace_bwd_filter_sizes_[" << i << "]: " << workspace_bwd_filter_sizes_[i] << "\n";
 #endif
 
@@ -403,7 +403,7 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
       ));
   
       bwd_data_algo_[i] = perf.bwd_data_algo;
-      DLOG(INFO) << "bwd_data_algo_[" << i << "]: " << bwd_data_algo_[i] << "\n";
+      LOG(INFO) << " - bwd_data_algo_[" << i << "]:   " << bwd_data_algo_[i];
       DLOG(INFO) << "workspace_bwd_data_sizes_[" << i << "]: " << workspace_bwd_data_sizes_[i] << "\n";
     }
 #endif // USE_MIOPEN_BACKWARD_DATA

--- a/src/caffe/layers/cudnn_conv_layer.cpp
+++ b/src/caffe/layers/cudnn_conv_layer.cpp
@@ -326,9 +326,6 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
     perf.bwd_weights_algo = miopenConvolutionBwdWeightsAlgoDirect;
     perf.bwd_data_algo = miopenConvolutionBwdDataAlgoDirect;
 
-#ifdef USE_MIOPEN_FORWARD_CONV
-    DLOG(INFO) << "miopenFindConvolutionForwardAlgorithm\n";
-
     // choose forward and backward algorithms + workspace(s)
     MIOPEN_CHECK(miopenFindConvolutionForwardAlgorithm(
         handle_,                  // handle
@@ -343,7 +340,7 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
         &ret_algo_count,          // returnedAlgoCount
         &perf,                    // perfResults
         workspace[0*this->group_ + g],             // workSpace
-        max_workspace,            // workSpaceSize
+        total_workspace_fwd,            // workSpaceSize
         false                     // exhaustiveSearch
     ));
 
@@ -371,7 +368,7 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
         &ret_algo_count,          // returnedAlgoCount
         &perf,                    // perfResults
         workspace[1*this->group_ + g],             // workSpace
-        max_workspace,            // workSpaceSize
+        total_workspace_bwd_filter,            // workSpaceSize
         false                     // exhaustiveSearch
     ));
 
@@ -399,7 +396,7 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
           &ret_algo_count,          // returnedAlgoCount
           &perf,                    // perfResults
           workspace[2*this->group_ + g],             // workSpace
-          max_workspace,            // workSpaceSize
+          total_workspace_bwd_data,            // workSpaceSize
           false                     // exhaustiveSearch
       ));
   

--- a/src/caffe/layers/cudnn_conv_layer.cpp
+++ b/src/caffe/layers/cudnn_conv_layer.cpp
@@ -348,6 +348,7 @@ void CuDNNConvolutionLayer<Dtype>::Reshape(
     ));
 
     fwd_algo_[i] = perf.fwd_algo;
+    LOG(INFO) << "(N, C, H, W): (" << N_ << ", " << C_ << ", " << H_ << ", " << W_ << ")";
     LOG(INFO) << " - fwd_algo_[" << i << "]:        " << fwd_algo_[i];
     DLOG(INFO) << "workspace_fwd_sizes_[" << i << "]:" << workspace_fwd_sizes_[i] << "\n";
 #endif

--- a/src/caffe/layers/cudnn_conv_layer_hip.cpp
+++ b/src/caffe/layers/cudnn_conv_layer_hip.cpp
@@ -6,19 +6,12 @@
 
 namespace caffe {
 
-#ifdef USE_CUDNN
-__global__ void sync_conv_groups() { }
-#endif
-
 template <typename Dtype>
 void CuDNNConvolutionLayer<Dtype>::Forward_gpu(
     const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
   const Dtype* weight = this->blobs_[0]->gpu_data();
 #ifdef USE_MIOPEN
 
-#if 0
-  LOG(INFO) << "CuDNNConvolutionLayer<Dtype>::Forward_gpu()\n";
-#endif
 #ifdef USE_MIOPEN_FORWARD_CONV
   for (int i = 0; i < bottom.size(); ++i) {
     const Dtype* bottom_data = bottom[i]->gpu_data();
@@ -70,42 +63,6 @@ void CuDNNConvolutionLayer<Dtype>::Forward_gpu(
   ConvolutionLayer<Dtype>::Forward_gpu(bottom, top);
 #endif  // USE_MIOPEN_FORWARD_CONV
 #endif  // USE_MIOPEN
-
-#ifdef USE_CUDNN
-  for (int i = 0; i < bottom.size(); ++i) {
-    const Dtype* bottom_data = bottom[i]->gpu_data();
-    Dtype* top_data = top[i]->mutable_gpu_data();
-
-    // Forward through cuDNN in parallel over groups.
-    for (int g = 0; g < this->group_; g++) {
-      // Filters.
-      CUDNN_CHECK(cudnnConvolutionForward(handle_,
-            cudnn::dataType<Dtype>::one,
-            bottom_descs_[i], bottom_data + bottom_offset_ * g,
-            filter_desc_, weight + this->weight_offset_ * g,
-            conv_descs_[i],
-            fwd_algo_[i], workspace[g], workspace_fwd_sizes_[i],
-            cudnn::dataType<Dtype>::zero,
-            top_descs_[i], top_data + top_offset_ * g));
-
-      // Bias.
-      if (this->bias_term_) {
-        const Dtype* bias_data = this->blobs_[1]->gpu_data();
-        CUDNN_CHECK(cudnnAddTensor(handle_,
-              cudnn::dataType<Dtype>::one,
-              bias_desc_, bias_data + bias_offset_ * g,
-              cudnn::dataType<Dtype>::one,
-              top_descs_[i], top_data + top_offset_ * g));
-      }
-    }
-
-    // Synchronize the work across groups, each of which went into its own
-    // stream, by launching an empty kernel into the default (null) stream.
-    // NOLINT_NEXT_LINE(whitespace/operators)
-    //hipLaunchKernelGGL(HIP_KERNEL_NAME(sync_conv_groups), dim3(1), dim3(1), 0, 0, );
-    sync_conv_groups<<<1, 1>>>();
-  }
-#endif
 }
 
 template <typename Dtype>
@@ -222,72 +179,6 @@ void CuDNNConvolutionLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   } // for top.size();
 #endif // USE_MIOPEN_BACKWARD_CONV
 #endif // USE_MIOPEN
-
-#if USE_CUDNN
-  const Dtype* weight = NULL;
-  Dtype* weight_diff = NULL;
-  if (this->param_propagate_down_[0]) {
-    weight = this->blobs_[0]->gpu_data();
-    weight_diff = this->blobs_[0]->mutable_gpu_diff();
-  }
-  Dtype* bias_diff = NULL;
-  if (this->bias_term_ && this->param_propagate_down_[1]) {
-    bias_diff = this->blobs_[1]->mutable_gpu_diff();
-  }
-  for (int i = 0; i < top.size(); ++i) {
-    const Dtype* top_diff = top[i]->gpu_diff();
-    // Backward through cuDNN in parallel over groups and gradients.
-    for (int g = 0; g < this->group_; g++) {
-      // Gradient w.r.t. bias.
-      if (this->bias_term_ && this->param_propagate_down_[1]) {
-        CUDNN_CHECK(cudnnConvolutionBackwardBias(handle_[0*this->group_ + g],
-              cudnn::dataType<Dtype>::one,
-              top_descs_[i],  top_diff + top_offset_ * g,
-              cudnn::dataType<Dtype>::one,
-              bias_desc_, bias_diff + bias_offset_ * g));
-      }
-
-      // Gradient w.r.t. weights.
-      if (this->param_propagate_down_[0]) {
-        const Dtype* bottom_data = bottom[i]->gpu_data();
-        CUDNN_CHECK(cudnnConvolutionBackwardFilter(
-              handle_[1*this->group_ + g],
-              cudnn::dataType<Dtype>::one,
-              bottom_descs_[i], bottom_data + bottom_offset_ * g,
-              top_descs_[i],    top_diff + top_offset_ * g,
-              conv_descs_[i],
-              bwd_filter_algo_[i], workspace[1*this->group_ + g],
-              workspace_bwd_filter_sizes_[i],
-              cudnn::dataType<Dtype>::one,
-              filter_desc_, weight_diff + this->weight_offset_ * g));
-      }
-
-      // Gradient w.r.t. bottom data.
-      if (propagate_down[i]) {
-        if (weight == NULL) {
-          weight = this->blobs_[0]->gpu_data();
-        }
-        Dtype* bottom_diff = bottom[i]->mutable_gpu_diff();
-        CUDNN_CHECK(cudnnConvolutionBackwardData(
-              handle_[2*this->group_ + g],
-              cudnn::dataType<Dtype>::one,
-              filter_desc_, weight + this->weight_offset_ * g,
-              top_descs_[i], top_diff + top_offset_ * g,
-              conv_descs_[i],
-              bwd_data_algo_[i], workspace[2*this->group_ + g],
-              workspace_bwd_data_sizes_[i],
-              cudnn::dataType<Dtype>::zero,
-              bottom_descs_[i], bottom_diff + bottom_offset_ * g));
-      }
-    }
-
-    // Synchronize the work across groups, each of which went into its own
-    // stream, by launching an empty kernel into the default (null) stream.
-    // NOLINT_NEXT_LINE(whitespace/operators)
-    //hipLaunchKernelGGL(HIP_KERNEL_NAME(sync_conv_groups), dim3(1), dim3(1), 0, 0, );
-    sync_conv_groups<<<1, 1>>>();
-  }
-#endif
 }
 
 INSTANTIATE_LAYER_GPU_FUNCS(CuDNNConvolutionLayer);

--- a/src/caffe/layers/cudnn_conv_layer_hip.cpp
+++ b/src/caffe/layers/cudnn_conv_layer_hip.cpp
@@ -72,12 +72,10 @@ void CuDNNConvolutionLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
 #ifdef USE_MIOPEN
 
 #ifndef USE_MIOPEN_BACKWARD_CONV
-  // TBD
   // Fall back to standard Caffe
   ConvolutionLayer<Dtype>::Backward_gpu(top, propagate_down, bottom);
 #else
 
-  //LOG(INFO) << "CuDNNConvolutionLayer<Dtype>::Backward_gpu()\n";
   const Dtype* weight = NULL;
   Dtype* weight_diff = NULL;
   if (this->param_propagate_down_[0]) {
@@ -131,7 +129,6 @@ void CuDNNConvolutionLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
         ));
 #else
         assert (g==0); // these equations do not account for g: - do we need another loop?
-        //LOG(INFO) << "CuDNNConvolutionLayer<Dtype>::Backward_gpu_weight fallback()\n";
         const Dtype* bottom_data = bottom[i]->gpu_data();
         for (int n = 0; n < this->num_; ++n) {
           // gradient w.r.t. weight. Note that we will accumulate diffs.
@@ -163,8 +160,6 @@ void CuDNNConvolutionLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
             workspace[2 * this->group_ + g],  // workSpace
             workspace_bwd_data_sizes_[i]      // workSpaceSize
         ));
-        //printf ("miopenConvolutionBackwardData\n");
-
 #else
         assert (g==0); // these equations do not account for g: - do we need another loop?
         // gradient w.r.t. bottom data, if necessary.

--- a/src/caffe/layers/cudnn_conv_layer_hip.cpp
+++ b/src/caffe/layers/cudnn_conv_layer_hip.cpp
@@ -145,6 +145,11 @@ void CuDNNConvolutionLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
           weight = this->blobs_[0]->gpu_data();
         }
 #ifdef USE_MIOPEN_BACKWARD_DATA
+        LOG(INFO) << "miopenConvolutionBackwardData(): i=" << i;
+        LOG(INFO) << " - fwd_algo_[" << i << "]:        " << fwd_algo_[i];
+        LOG(INFO) << " - bwd_weight_algo_[" << i << "]: " << bwd_weight_algo_[i];
+        LOG(INFO) << " - bwd_data_algo_[" << i << "]:   " << bwd_data_algo_[i];
+
         MIOPEN_CHECK(miopenConvolutionBackwardData(
             handle_,                           // handle
             miopen::dataType<Dtype>::one,      // *alpha

--- a/src/caffe/layers/cudnn_lcn_layer.cpp
+++ b/src/caffe/layers/cudnn_lcn_layer.cpp
@@ -65,8 +65,13 @@ void CuDNNLCNLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
 
   if (totalSizeInBytes > tempDataSize) {
     // Note: reporting two reallocations because of the two hipMallocs below
-    DLOG(INFO) << "Reallocating temp storage " << this->layer_param().name() << "  " << totalSizeInBytes/1024.0/1024.0 << " MB\n";
-    DLOG(INFO) << "Reallocating temp storage " << this->layer_param().name() << "  " << totalSizeInBytes/1024.0/1024.0 << " MB\n";
+    if (tempDataSize == 0) {
+      DLOG(INFO) << "Allocating temp storage " << this->layer_param().name() << "  " << totalSizeInBytes/1024.0/1024.0 << " MB\n";
+      DLOG(INFO) << "Allocating temp storage " << this->layer_param().name() << "  " << totalSizeInBytes/1024.0/1024.0 << " MB\n";
+    } else {
+      DLOG(INFO) << "Reallocating temp storage " << this->layer_param().name() << "  " << totalSizeInBytes/1024.0/1024.0 << " MB\n";
+      DLOG(INFO) << "Reallocating temp storage " << this->layer_param().name() << "  " << totalSizeInBytes/1024.0/1024.0 << " MB\n";
+    }
 
     tempDataSize = totalSizeInBytes;
 

--- a/src/caffe/layers/cudnn_lrn_layer.cpp
+++ b/src/caffe/layers/cudnn_lrn_layer.cpp
@@ -54,7 +54,11 @@ void CuDNNLRNLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   miopenLRNGetWorkSpaceSize(top_desc_, &totalSizeInBytes);
 
   if (totalSizeInBytes > workspaceSize) {
-    DLOG(INFO) << "Reallocating workspace storage " << this->layer_param().name() << "  " << totalSizeInBytes/1024.0/1024.0 << " MB\n";
+    if (workspaceSize == 0) {
+      LOG(INFO) << "Allocating workspace storage " << this->layer_param().name() << "  " << totalSizeInBytes/1024.0/1024.0 << " MB\n";
+    } else {
+      DLOG(INFO) << "Reallocating workspace storage " << this->layer_param().name() << "  " << totalSizeInBytes/1024.0/1024.0 << " MB\n";
+    }
 
     workspaceSize = totalSizeInBytes;
 

--- a/src/caffe/layers/cudnn_pooling_layer.cpp
+++ b/src/caffe/layers/cudnn_pooling_layer.cpp
@@ -52,7 +52,11 @@ void CuDNNPoolingLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   miopenPoolingGetWorkSpaceSize(top_desc_, &totalSizeInBytes);
 
   if (totalSizeInBytes > workspaceSize) {
-    DLOG(INFO) << "Reallocating workspace storage " << this->layer_param().name() << "  " << totalSizeInBytes/1024.0/1024.0 << " MB\n";
+    if (workspaceSize == 0) {
+      DLOG(INFO) << "Allocating workspace storage " << this->layer_param().name() << "  " << totalSizeInBytes/1024.0/1024.0 << " MB\n";
+    } else {
+      DLOG(INFO) << "Reallocating workspace storage " << this->layer_param().name() << "  " << totalSizeInBytes/1024.0/1024.0 << " MB\n";
+    }
 
     workspaceSize = totalSizeInBytes;
 

--- a/src/caffe/parallel.cpp
+++ b/src/caffe/parallel.cpp
@@ -270,6 +270,7 @@ P2PSync<Dtype>::~P2PSync() {
 
 template<typename Dtype>
 void P2PSync<Dtype>::InternalThreadEntry() {
+  DLOG(INFO) << "P2PSync<Dtype>::InternalThreadEntry()";
   Caffe::SetDevice(solver_->param().device_id());
   CHECK(Caffe::root_solver());
   Caffe::set_root_solver(false);
@@ -426,13 +427,17 @@ void P2PSync<Dtype>::Run(const vector<int>& gpus) {
 
   LOG(INFO)<< "Starting Optimization";
 
+  DLOG(INFO) << "Start " << (syncs.size() - 1) << " threads";
   for (int i = 1; i < syncs.size(); ++i) {
     syncs[i]->StartInternalThread();
   }
 
+  DLOG(INFO) << "Run root solver";
+
   // Run root solver on current thread
   solver_->Solve();
 
+  DLOG(INFO) << "Stop " << (syncs.size() - 1) << " threads";
   for (int i = 1; i < syncs.size(); ++i) {
     syncs[i]->StopInternalThread();
   }

--- a/src/caffe/parallel.cpp
+++ b/src/caffe/parallel.cpp
@@ -211,8 +211,8 @@ P2PSync<Dtype>::P2PSync(shared_ptr<Solver<Dtype> > root_solver,
 #ifndef CPU_ONLY
   int initial_device;
   HIP_CHECK(hipGetDevice(&initial_device));
-  const int self = param.device_id();
-  HIP_CHECK(hipSetDevice(self));
+  this->device_ = param.device_id();
+  HIP_CHECK(hipSetDevice(device_));
 
   if (parent == NULL) {
     solver_ = root_solver;
@@ -228,16 +228,16 @@ P2PSync<Dtype>::P2PSync(shared_ptr<Solver<Dtype> > root_solver,
     // Enable p2p access between devices
     const int peer = parent->solver_->param().device_id();
     int access;
-    HIP_CHECK(hipDeviceCanAccessPeer(&access, self, peer));
+    HIP_CHECK(hipDeviceCanAccessPeer(&access, device_, peer));
     if (access) {
       HIP_CHECK(hipDeviceEnablePeerAccess(peer, 0));
     } else {
-      LOG(INFO)<< "GPU " << self << " does not have p2p access to GPU " << peer;
+      LOG(INFO)<< "GPU " << device_ << " does not have p2p access to GPU " << peer;
     }
     // Allocate receiving buffer on parent
     HIP_CHECK(hipSetDevice(peer));
     HIP_CHECK(hipMalloc(&parent_grads_, size_ * sizeof(Dtype)));
-    HIP_CHECK(hipSetDevice(self));
+    HIP_CHECK(hipSetDevice(device_));
   }
 
   HIP_CHECK(hipSetDevice(initial_device));

--- a/src/caffe/parallel.cpp
+++ b/src/caffe/parallel.cpp
@@ -12,6 +12,8 @@
 #include "caffe/caffe.hpp"
 #include "caffe/parallel.hpp"
 
+#include "caffe/layers/cudnn_conv_layer.hpp"
+
 namespace caffe {
 
 enum Op {
@@ -270,7 +272,9 @@ P2PSync<Dtype>::~P2PSync() {
 
 template<typename Dtype>
 void P2PSync<Dtype>::InternalThreadEntry() {
-  DLOG(INFO) << "P2PSync<Dtype>::InternalThreadEntry()";
+  LOG(INFO) << "P2PSync<Dtype>::InternalThreadEntry() for device" << solver_->param().device_id();
+
+  LOG(INFO) << "Call Caffe::SetDevice(" << solver_->param().device_id() << ")";
   Caffe::SetDevice(solver_->param().device_id());
   CHECK(Caffe::root_solver());
   Caffe::set_root_solver(false);
@@ -282,6 +286,25 @@ void P2PSync<Dtype>::InternalThreadEntry() {
     Caffe::set_random_seed(
         solver_->param().random_seed() + solver_->param().device_id());
   }
+
+  LOG(INFO) << "# of layers: " << solver_->net()->layers().size() << " on device " << solver_->param().device_id();
+  size_t cudnn_conv_layer_count = 0;
+  for (size_t i = 0; i < solver_->net()->layers().size(); ++i) {
+    shared_ptr<Layer<Dtype> > layer = solver_->net()->layers().at(i);
+    Layer<Dtype>* raw_layer = layer.get();
+    if (CuDNNConvolutionLayer<Dtype>* raw_cudnn_layer = dynamic_cast<CuDNNConvolutionLayer<Dtype>*>(raw_layer)) {
+      ++cudnn_conv_layer_count;
+      
+      for (size_t j = 0; j < raw_cudnn_layer->fwd_algo_.size(); j++) {
+        LOG(INFO) << " - fwd_algo_[" << j << "]:        " << raw_cudnn_layer->fwd_algo_[j];
+        LOG(INFO) << " - bwd_weight_algo_[" << j << "]: " << raw_cudnn_layer->bwd_weight_algo_[j];
+        LOG(INFO) << " - bwd_data_algo_[" << j << "]:   " << raw_cudnn_layer->bwd_data_algo_[j];
+      }
+
+    }
+  }
+  LOG(INFO) << "# of CuDNNConvolutionLayer: " << cudnn_conv_layer_count << " on device " << solver_->param().device_id();
+
   solver_->Step(solver_->param().max_iter() - initial_iter_);
 }
 

--- a/src/caffe/solver.cpp
+++ b/src/caffe/solver.cpp
@@ -263,7 +263,7 @@ void Solver<Dtype>::Step(int iters) {
          && iter_ % param_.snapshot() == 0
          && Caffe::root_solver()) ||
          (request == SolverAction::SNAPSHOT)) {
-      Snapshot();
+      //Snapshot();
     }
     if (SolverAction::STOP == request) {
       requested_early_exit_ = true;
@@ -295,7 +295,7 @@ void Solver<Dtype>::Solve(const char* resume_file) {
   // overridden by setting snapshot_after_train := false
   if (param_.snapshot_after_train()
       && (!param_.snapshot() || iter_ % param_.snapshot() != 0)) {
-    Snapshot();
+    //Snapshot();
   }
   if (requested_early_exit_) {
     LOG(INFO) << "Optimization stopped early.";
@@ -347,7 +347,7 @@ void Solver<Dtype>::Test(const int test_net_id) {
     // Check to see if stoppage of testing/training has been requested.
     while (request != SolverAction::NONE) {
         if (SolverAction::SNAPSHOT == request) {
-          Snapshot();
+          //Snapshot();
         } else if (SolverAction::STOP == request) {
           requested_early_exit_ = true;
         }


### PR DESCRIPTION
Use `std::vector` instead of `new/delete` in member variables of `CuDNNConvolutionLayer` to help improve stability.

Please review and merge this PR after #30 .